### PR TITLE
use hidden special buffer name for throw-away buffer

### DIFF
--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -337,7 +337,7 @@ Where the file was a .elc, return the path to the .el file instead."
   "Read PATH into a disposable buffer, and return it.
 Works around the fact that Emacs won't allow multiple buffers
 visiting the same file."
-  (let ((fresh-buffer (generate-new-buffer (format "refs-%s" path))))
+  (let ((fresh-buffer (generate-new-buffer (format " *refs-%s*" path))))
     (with-current-buffer fresh-buffer
       (setq-local elisp-refs--path path)
       (insert-file-contents path)


### PR DESCRIPTION
i use a function in `kill-buffer-query-functions` to ask for modified but unsaved files. it does inspect the buffer name to avoid prompting for throw-away buffers, which are use pervasively in emacs. this buffer name check is basically `(string-match-p "\*" name)` which works great in practice... except for this package which uses a "normal" buffer name for some of its throw-away buffers. this pr addresses that.