### PR TITLE
Require a valid version of loop.el

### DIFF
--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -5,7 +5,7 @@
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Version: 1.3
 ;; Keywords: lisp
-;; Package-Requires: ((dash "2.12.0") (f "0.18.2") (list-utils "0.4.4") (loop "2.1") (s "1.11.0"))
+;; Package-Requires: ((dash "2.12.0") (f "0.18.2") (list-utils "0.4.4") (loop "1.2") (s "1.11.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
`elisp-refs` and, by extension, `helpful` are currently not installable from MELPA Stable.  This is because `elisp-refs` requires a non-existent version 2.1 of `loop.el`.  It seems to me that this was just a typo, perhaps a transposition.  I didn't actually test this, but since `elisp-refs` only uses `loop-while` and that macro hasn't changed since version 1.2 of `loop.el`, I think that version should be sufficient.