### PR TITLE
Define elisp-refs-mode-map using defvar

### DIFF
--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -749,6 +749,20 @@ search."
                         (elisp-refs--read-and-find-symbol buf symbol))
                       path-prefix))
 
+(defvar elisp-refs-mode-map
+  (let ((map (make-sparse-keymap)))
+    ;; TODO: it would be nice for TAB to navigate to file buttons too,
+    ;; like *Help* does.
+    (set-keymap-parent map special-mode-map)
+    (define-key map (kbd "<tab>") #'elisp-refs-next-match)
+    (define-key map (kbd "<backtab>") #'elisp-refs-prev-match)
+    (define-key map (kbd "n") #'elisp-refs-next-match)
+    (define-key map (kbd "p") #'elisp-refs-prev-match)
+    (define-key map (kbd "q") #'kill-this-buffer)
+    (define-key map (kbd "RET") #'elisp-refs-visit-match)
+    map)
+  "Keymap for `elisp-refs-mode'.")
+
 (define-derived-mode elisp-refs-mode special-mode "Refs"
   "Major mode for refs results buffers.")
 
@@ -826,15 +840,6 @@ If DIRECTION is -1, moves backwards instead."
   "Move to the next search result in the Refs buffer."
   (interactive)
   (elisp-refs--move-to-match 1))
-
-;; TODO: it would be nice for TAB to navigate to file buttons too,
-;; like *Help* does.
-(define-key elisp-refs-mode-map (kbd "<tab>") #'elisp-refs-next-match)
-(define-key elisp-refs-mode-map (kbd "<backtab>") #'elisp-refs-prev-match)
-(define-key elisp-refs-mode-map (kbd "n") #'elisp-refs-next-match)
-(define-key elisp-refs-mode-map (kbd "p") #'elisp-refs-prev-match)
-(define-key elisp-refs-mode-map (kbd "q") #'kill-this-buffer)
-(define-key elisp-refs-mode-map (kbd "RET") #'elisp-refs-visit-match)
 
 (provide 'elisp-refs)
 ;;; elisp-refs.el ends here


### PR DESCRIPTION
This makes it possible for contributors to do `eval-buffer`
without discarding their personal key bindings every time.

Could you please do that for your other packages too? At least `helpful` does the same thing.