### PR TITLE
Some cleanup and no longer depend on loop

### DIFF
--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -37,6 +37,8 @@
 (require 'format)
 (eval-when-compile (require 'cl-lib))
 
+;;; Internal
+
 (defvar elisp-refs-verbose t)
 
 (defun elisp-refs--format-int (integer)
@@ -656,6 +658,8 @@ t."
                           (when (funcall filter (read sym))
                             sym))))))
 
+;;; Commands
+
 ;;;###autoload
 (defun elisp-refs-function (symbol &optional path-prefix)
   "Display all the references to function SYMBOL, in all loaded
@@ -757,6 +761,8 @@ search."
                       (lambda (buf)
                         (elisp-refs--read-and-find-symbol buf symbol))
                       path-prefix))
+
+;;; Mode
 
 (defvar elisp-refs-mode-map
   (let ((map (make-sparse-keymap)))

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -40,7 +40,7 @@
 (defvar elisp-refs-verbose t)
 
 (defun elisp-refs--format-int (integer)
-  "Format INTEGER as a string, with \",\" separating thousands."
+  "Format INTEGER as a string, with , separating thousands."
   (let ((number (abs integer))
         (parts nil))
     (while (> number 999)

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -1,6 +1,6 @@
 ;;; elisp-refs.el --- find callers of elisp functions or macros -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2016-2018
+;; Copyright (C) 2016-2020  Wilfred Hughes <me@wilfred.me.uk>
 
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Version: 1.4

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -5,7 +5,7 @@
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Version: 1.4
 ;; Keywords: lisp
-;; Package-Requires: ((dash "2.12.0") (loop "1.2") (s "1.11.0"))
+;; Package-Requires: ((dash "2.12.0") (s "1.11.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -33,7 +33,6 @@
 ;;; Code:
 
 (require 'dash)
-(require 'loop)
 (require 's)
 (require 'format)
 (eval-when-compile (require 'cl-lib))
@@ -70,18 +69,18 @@ Not recursive, so we don't consider subelements of nested sexps."
   (let ((positions nil))
     (with-current-buffer buffer
       (condition-case _err
-          ;; Loop until we can't read any more.
-          (loop-while t
-            (let* ((sexp-end-pos (let ((parse-sexp-ignore-comments t))
-                                   (scan-sexps start-pos 1))))
-              ;; If we've reached a sexp beyond the range requested,
-              ;; or if there are no sexps left, we're done.
-              (when (or (null sexp-end-pos) (> sexp-end-pos end-pos))
-                (loop-break))
-              ;; Otherwise, this sexp is in the range requested.
-              (push (list (elisp-refs--start-pos sexp-end-pos) sexp-end-pos)
-                    positions)
-              (setq start-pos sexp-end-pos)))
+	  (catch 'done
+            (while t
+              (let* ((sexp-end-pos (let ((parse-sexp-ignore-comments t))
+                                     (scan-sexps start-pos 1))))
+		;; If we've reached a sexp beyond the range requested,
+		;; or if there are no sexps left, we're done.
+		(when (or (null sexp-end-pos) (> sexp-end-pos end-pos))
+                  (throw 'done nil))
+		;; Otherwise, this sexp is in the range requested.
+		(push (list (elisp-refs--start-pos sexp-end-pos) sexp-end-pos)
+                      positions)
+		(setq start-pos sexp-end-pos))))
         ;; Terminate when we see "Containing expression ends prematurely"
         (scan-error nil)))
     (nreverse positions)))

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -40,9 +40,9 @@
 (defvar elisp-refs-verbose t)
 
 (defun elisp-refs--format-int (integer)
-  "Format INTEGER as a string, with , separating thousands."
-  (let* ((number (abs integer))
-         (parts nil))
+  "Format INTEGER as a string, with \",\" separating thousands."
+  (let ((number (abs integer))
+        (parts nil))
     (while (> number 999)
       (push (format "%03d" (mod number 1000))
             parts)

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -552,33 +552,32 @@ KIND should be 'function, 'macro, 'variable, 'special or 'symbol."
 render a friendly results buffer."
   (let ((buf (get-buffer-create (format "*refs: %s*" symbol))))
     (switch-to-buffer buf)
-    (setq buffer-read-only nil)
-    (erase-buffer)
-    ;; Insert the header.
-    (insert
-     (elisp-refs--format-count
-      description
-      (-sum (--map (length (car it)) results))
-      (length results)
-      searched-file-count
-      prefix)
-     "\n\n")
-    ;; Insert the results.
-    (--each results
-      (-let* (((forms . buf) it)
-              (path (with-current-buffer buf elisp-refs--path)))
-        (insert
-         (propertize "File: " 'face 'bold)
-         (elisp-refs--path-button path) "\n")
-        (--each forms
-          (-let [(_ start-pos end-pos) it]
-            (insert (elisp-refs--containing-lines buf start-pos end-pos)
-                    "\n")))
-        (insert "\n")))
-    ;; Prepare the buffer for the user.
-    (goto-char (point-min))
-    (elisp-refs-mode)
-    (setq buffer-read-only t)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      ;; Insert the header.
+      (insert
+       (elisp-refs--format-count
+        description
+        (-sum (--map (length (car it)) results))
+        (length results)
+        searched-file-count
+        prefix)
+       "\n\n")
+      ;; Insert the results.
+      (--each results
+        (-let* (((forms . buf) it)
+                (path (with-current-buffer buf elisp-refs--path)))
+          (insert
+           (propertize "File: " 'face 'bold)
+           (elisp-refs--path-button path) "\n")
+          (--each forms
+            (-let [(_ start-pos end-pos) it]
+              (insert (elisp-refs--containing-lines buf start-pos end-pos)
+                      "\n")))
+          (insert "\n")))
+      ;; Prepare the buffer for the user.
+      (goto-char (point-min))
+      (elisp-refs-mode))
     ;; Cleanup buffers created when highlighting results.
     (kill-buffer elisp-refs--highlighting-buffer)))
 

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -554,30 +554,30 @@ render a friendly results buffer."
     (switch-to-buffer buf)
     (let ((inhibit-read-only t))
       (erase-buffer)
-      ;; Insert the header.
-      (insert
-       (elisp-refs--format-count
-        description
-        (-sum (--map (length (car it)) results))
-        (length results)
-        searched-file-count
-        prefix)
-       "\n\n")
-      ;; Insert the results.
-      (--each results
-        (-let* (((forms . buf) it)
-                (path (with-current-buffer buf elisp-refs--path)))
-          (insert
-           (propertize "File: " 'face 'bold)
-           (elisp-refs--path-button path) "\n")
-          (--each forms
-            (-let [(_ start-pos end-pos) it]
-              (insert (elisp-refs--containing-lines buf start-pos end-pos)
-                      "\n")))
-          (insert "\n")))
-      ;; Prepare the buffer for the user.
-      (goto-char (point-min))
-      (elisp-refs-mode))
+      (save-excursion
+        ;; Insert the header.
+        (insert
+         (elisp-refs--format-count
+          description
+          (-sum (--map (length (car it)) results))
+          (length results)
+          searched-file-count
+          prefix)
+         "\n\n")
+        ;; Insert the results.
+        (--each results
+          (-let* (((forms . buf) it)
+                  (path (with-current-buffer buf elisp-refs--path)))
+            (insert
+             (propertize "File: " 'face 'bold)
+             (elisp-refs--path-button path) "\n")
+            (--each forms
+              (-let [(_ start-pos end-pos) it]
+                (insert (elisp-refs--containing-lines buf start-pos end-pos)
+                        "\n")))
+            (insert "\n")))
+        ;; Prepare the buffer for the user.
+        (elisp-refs-mode)))
     ;; Cleanup buffers created when highlighting results.
     (kill-buffer elisp-refs--highlighting-buffer)))
 


### PR DESCRIPTION
Two years ago, in #21, I experimented with using `magit-section.el` in this package.  Recently I released that library as separate package, so I picked that experiment up again.  If nothing else it might serve as an example for how to use `magit-section` in a package that isn't Magit.

Anyway, I did some cleanup while working on that and now propose those changes using this this pull request.

I am aware that you are the author of `loop` but I still think you should avoid depending on an additional package just to make a single function slightly ~less~ more readable.