### PR TITLE
Use magit sections to display results

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package-file "elisp-refs.el")

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -88,6 +88,9 @@ Not recursive, so we don't consider subelements of nested sexps."
         (scan-error nil)))
     (nreverse positions)))
 
+;; Removed in dfae76c9915454f9ef0885e1bac160a2c480e1d1.
+(defvar read-with-symbol-positions)
+
 (defun elisp-refs--read-buffer-form ()
   "Read a form from the current buffer, starting at point.
 Returns a list:

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -574,15 +574,15 @@ render a friendly results buffer."
                      searched-file-count
                      prefix))
             (insert "\n\n"))
-          (--each results
-            (-let* (((forms . buf) it)
-                    (path (buffer-local-value 'elisp-refs--path buf)))
+          (dolist (result results)
+            (pcase-let* ((`(,forms . ,buf) result)
+			 (path (buffer-local-value 'elisp-refs--path buf)))
               (magit-insert-section (elisp-refs-file path)
                 (magit-insert-heading
                   (propertize "File: " 'face 'bold)
                   (elisp-refs--path-button path) ":\n")
-                (--each forms
-                  (-let [(_ start-pos end-pos) it]
+                (dolist (form forms)
+                  (pcase-let ((`(,_ ,start-pos ,end-pos) form))
                     (magit-insert-section (elisp-refs-match
                                            (list start-pos end-pos))
                       (insert (elisp-refs--containing-lines

--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -5,7 +5,7 @@
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Version: 1.5
 ;; Keywords: lisp
-;; Package-Requires: ((dash "2.12.0") (magit-section "3.0.0") (s "1.11.0"))
+;; Package-Requires: ((dash "2.12.0") (magit-section "3.3.0") (s "1.11.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/test/elisp-refs-unit-test.el
+++ b/test/elisp-refs-unit-test.el
@@ -464,7 +464,7 @@ backquote forms."
     (elisp-refs-function 'ash))
   ;; After moving to the first result, we should have a property that
   ;; tells us where the result came from.
-  (elisp-refs-next-match)
+  (magit-section-forward)
   (should
    (not (null (get-text-property (point) 'elisp-refs-start-pos)))))
 


### PR DESCRIPTION
By doing so we can get rid of some code while gaining features.
For example, files can now be collapsed globally using "M-1" or
individually using "TAB".

I first brought this up in #21, but back then `magit-section` was not available as a stand-alone package yet.  Now that it is available, using it seems like a clear win.

This pull-request also contains the cleanup commits from my earlier outstanding pull-request #26.