### PR TITLE
update elisp-refs--read-buffer-form for emacs 29

### DIFF
--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -96,9 +96,12 @@ SYMBOL-POSITIONS are 0-indexed, relative to READ-START-POS."
   (let* ((read-with-symbol-positions t)
          (read-start-pos (point))
          (form (read (current-buffer)))
+         (symbols (if (boundp 'read-symbol-positions-list)
+                      read-symbol-positions-list
+                    (read-positioning-symbols (current-buffer))))
          (end-pos (point))
          (start-pos (elisp-refs--start-pos end-pos)))
-    (list form start-pos end-pos read-symbol-positions-list read-start-pos)))
+    (list form start-pos end-pos symbols read-start-pos)))
 
 (defvar elisp-refs--path nil
   "A buffer-local variable used by `elisp-refs--contents-buffer'.


### PR DESCRIPTION
This has provided a fix for deprecation of read-symbol-positions-list in
a recent commit for Emacs 29
https://github.com/emacs-mirror/emacs/commit/dfae76c9915454f9ef0885e1bac160a2c480e1d1.

It has fixed the issue with Helpful along with some of the changes from
this PR https://github.com/Wilfred/helpful/pull/283