### PR TITLE
Remove kill buffer key binding

### DIFF
--- a/elisp-refs.el
+++ b/elisp-refs.el
@@ -813,7 +813,6 @@ search."
     (define-key map (kbd "<backtab>") #'elisp-refs-prev-match)
     (define-key map (kbd "n") #'elisp-refs-next-match)
     (define-key map (kbd "p") #'elisp-refs-prev-match)
-    (define-key map (kbd "q") #'kill-this-buffer)
     (define-key map (kbd "RET") #'elisp-refs-visit-match)
     map)
   "Keymap for `elisp-refs-mode'.")


### PR DESCRIPTION
`elisp-refs-mode` derives from `special-mode`, which already has `q` bound to `quit-window`. Most special mode derivatives leave this alone so `quit-restore-window` can decide what the right thing to do it. With `q` bound to `kill-buffer`, `quit-restore-window` doesn't have a chance to run and leaves a duplicate window showing some already shown buffer when window managers like `window-purpose` is active.